### PR TITLE
Made changes to enable compilation on Windows 

### DIFF
--- a/owa-epanet/CMakeLists.txt
+++ b/owa-epanet/CMakeLists.txt
@@ -8,7 +8,14 @@ endif()
 
 find_package(PythonLibs 3 REQUIRED)
 find_package(PythonInterp ${PYTHONLIBS_VERSION_STRING} REQUIRED)
-set(PYTHON_EXECUTABLE "c:/python/python38/python.exe")
+# If find_package() has difficulty finding the appropriate python 
+# directories and libraries (especially in Windows with multiple 
+# versions of python) set them manually as in the next three lines 
+# below (and comment out the above two find_package() lines):
+# set(PYTHON_EXECUTABLE "c:/python/python38/python.exe")
+# set(PYTHON_INCLUDE_PATH "c:/python/python38/include")
+# set(PYTHON_LIBRARIES "c:/python/python38/libs/python38.lib")
+
 find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 set(CMAKE_SWIG_FLAGS -py3)
@@ -59,17 +66,26 @@ add_custom_command(
                 ${CMAKE_CURRENT_BINARY_DIR}/toolkit.py
                 ${CMAKE_CURRENT_BINARY_DIR}/../../../packages/epanet/toolkit.py)
 
-add_custom_command(
-        TARGET _toolkit POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-                ${CMAKE_CURRENT_BINARY_DIR}/lib/Release/_toolkit.pyd
-                ${CMAKE_CURRENT_BINARY_DIR}/../../../packages/epanet/_toolkit.pyd)
+IF(WIN32)
+    add_custom_command(
+            TARGET _toolkit POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+                    ${CMAKE_CURRENT_BINARY_DIR}/lib/Release/_toolkit.pyd
+                    ${CMAKE_CURRENT_BINARY_DIR}/../../../packages/epanet/_toolkit.pyd)
+    add_custom_command(
+            TARGET _toolkit POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+                    ${CMAKE_CURRENT_BINARY_DIR}/lib/Release/epanet2.lib
+                    ${CMAKE_CURRENT_BINARY_DIR}/../../../packages/epanet/epanet2.lib)
+ELSE(True)
+    add_custom_command(
+            TARGET _toolkit POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+                    ${CMAKE_CURRENT_BINARY_DIR}/lib/libepanet2.*
+                    ${CMAKE_CURRENT_BINARY_DIR}/../../../packages/epanet/)
+ENDIF(WIN32)
 
-add_custom_command(
-        TARGET _toolkit POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-                ${CMAKE_CURRENT_BINARY_DIR}/lib/Release/epanet2.lib
-                ${CMAKE_CURRENT_BINARY_DIR}/../../../packages/epanet/epanet2.lib)
+
 
 #add_custom_command(
 #        TARGET _toolkit POST_BUILD

--- a/owa-epanet/CMakeLists.txt
+++ b/owa-epanet/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 3.8)
 
+project(OWA-EPANET)
+
 if(SKBUILD)
   message(STATUS "The project is built using scikit-build")
 endif()
 
 find_package(PythonLibs 3 REQUIRED)
 find_package(PythonInterp ${PYTHONLIBS_VERSION_STRING} REQUIRED)
+set(PYTHON_EXECUTABLE "c:/python/python38/python.exe")
 find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 set(CMAKE_SWIG_FLAGS -py3)
@@ -33,6 +36,7 @@ SWIG_ADD_LIBRARY( toolkit LANGUAGE python SOURCES wrapper/toolkit.i )
 set_property(SOURCE toolkit.i PROPERTY USE_LIBRARY_INCLUDE_DIRECTORIES TRUE)
 set_property(TARGET epanet2 PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES TRUE)
 SWIG_LINK_LIBRARIES(toolkit epanet2)
+
 SWIG_LINK_LIBRARIES(toolkit ${PYTHON_LIBRARIES})
 set_property(TARGET _toolkit PROPERTY INSTALL_RPATH "$ORIGIN")
 
@@ -58,9 +62,14 @@ add_custom_command(
 add_custom_command(
         TARGET _toolkit POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-                ${CMAKE_CURRENT_BINARY_DIR}/lib/libepanet2.*
-                ${CMAKE_CURRENT_BINARY_DIR}/../../../packages/epanet/)
+                ${CMAKE_CURRENT_BINARY_DIR}/lib/Release/_toolkit.pyd
+                ${CMAKE_CURRENT_BINARY_DIR}/../../../packages/epanet/_toolkit.pyd)
 
+add_custom_command(
+        TARGET _toolkit POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_CURRENT_BINARY_DIR}/lib/Release/epanet2.lib
+                ${CMAKE_CURRENT_BINARY_DIR}/../../../packages/epanet/epanet2.lib)
 
 #add_custom_command(
 #        TARGET _toolkit POST_BUILD

--- a/owa-epanet/CMakeLists.txt
+++ b/owa-epanet/CMakeLists.txt
@@ -75,8 +75,8 @@ IF(WIN32)
     add_custom_command(
             TARGET _toolkit POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy
-                    ${CMAKE_CURRENT_BINARY_DIR}/lib/Release/epanet2.lib
-                    ${CMAKE_CURRENT_BINARY_DIR}/../../../packages/epanet/epanet2.lib)
+                    ${CMAKE_CURRENT_BINARY_DIR}/bin/Release/epanet2.dll
+                    ${CMAKE_CURRENT_BINARY_DIR}/../../../packages/epanet/epanet2.dll)
 ELSE(True)
     add_custom_command(
             TARGET _toolkit POST_BUILD

--- a/owa-epanet/README.md
+++ b/owa-epanet/README.md
@@ -4,10 +4,17 @@ A slender, auto-generated python wrapper around owa:epanet hydraulic network ana
 
 Where possible, SWIG has been configured to throw warnings/exceptions instead of using the customary EPANET return integer value for success-checking. Also any output (pointer) parameters from the C API have been re-routed to return values. In these cases, the return tuple from the Python API will contain the values desired.
 
-```
 
+## Building the libraries
+
+Ensure the EPANET subproject is populated by running `git submodule update --init` (if necessary) and running the following commands (on Windows skip the line `./script/clean.sh`). The following method uses `scikit-build` to invoke `cmake` for compiling and linking the shared libaries, and builds a python wheel.
+
+```
 ./scripts/clean.sh
 python3 setup.py sdist bdist_wheel
+```
+Test your builds using the following commands.
+```
 cd test && pipenv install ../dist/*.whl && pipenv run python -c 'from epanet import toolkit; print(toolkit.__dict__)'
 
 ```

--- a/owa-epanet/build_owa-epanet.bat
+++ b/owa-epanet/build_owa-epanet.bat
@@ -1,18 +1,20 @@
 cls
 
+rem Bulding the toolkit package for Windows. The preferred way to build the package is by running 'python setup.py sdist bdist_wheel'.
+
 git submodule update --init
 
-SET CMAKE_PATH=cmake.exe 
+SET CMAKE_PATH=cmake.exe
 SET Build_PATH=%CD%
-SET COMPILE_PATH=%Build_PATH%\build\
+SET COMPILE_PATH=%Build_PATH%\_cmake_build\windows\cmake-build
 
 MKDIR "%COMPILE_PATH%"
 CD "%COMPILE_PATH%"
 rem Building 64-bit toolkit for 64-bit python.
-rem If 32-bit toolkit is required ensure 32-bit python is located 
+rem If 32-bit toolkit is required ensure 32-bit python is located
 rem by cmake (check CmakeList.txt) and replace '%CMAKE_PATH% ../ -A x64'
 rem with '%CMAKE_PATH% ../ -A Win32'."
-%CMAKE_PATH% ../ -A x64
+%CMAKE_PATH% ../../../ -A x64
 %CMAKE_PATH% --build . --config Release
 
 rem 'After successful compilation "toolkit.py", "_toolkit.pyd", "epanet2.dll" will be created. You can start using the toolkit by importing the module "toolkit.py".

--- a/owa-epanet/build_owa-epanet.bat
+++ b/owa-epanet/build_owa-epanet.bat
@@ -1,5 +1,7 @@
 cls
 
+git clone --branch=dev https://github.com/OpenWaterAnalytics/EPANET.git
+
 SET CMAKE_PATH=cmake.exe 
 SET Build_PATH=%CD%
 SET COMPILE_PATH=%Build_PATH%\build\

--- a/owa-epanet/build_owa-epanet.bat
+++ b/owa-epanet/build_owa-epanet.bat
@@ -1,0 +1,13 @@
+cls
+
+SET CMAKE_PATH=cmake.exe 
+SET Build_PATH=%CD%
+SET COMPILE_PATH=%Build_PATH%\build\
+
+MKDIR "%COMPILE_PATH%"
+CD "%COMPILE_PATH%"
+%CMAKE_PATH% ../ -A x64
+%CMAKE_PATH% --build . --config Release
+
+cd ..
+pause

--- a/owa-epanet/build_owa-epanet.bat
+++ b/owa-epanet/build_owa-epanet.bat
@@ -6,6 +6,10 @@ SET COMPILE_PATH=%Build_PATH%\build\
 
 MKDIR "%COMPILE_PATH%"
 CD "%COMPILE_PATH%"
+rem Building 64-bit toolkit for 64-bit python.
+rem If 32-bit toolkit is required ensure 32-bit python is located 
+rem by cmake (check CmakeList.txt) and replace '%CMAKE_PATH% ../ -A x64'
+rem with '%CMAKE_PATH% ../ -A Win32'."
 %CMAKE_PATH% ../ -A x64
 %CMAKE_PATH% --build . --config Release
 

--- a/owa-epanet/build_owa-epanet.bat
+++ b/owa-epanet/build_owa-epanet.bat
@@ -1,6 +1,6 @@
 cls
 
-git clone --branch=dev https://github.com/OpenWaterAnalytics/EPANET.git
+git submodule update --init
 
 SET CMAKE_PATH=cmake.exe 
 SET Build_PATH=%CD%
@@ -14,6 +14,8 @@ rem by cmake (check CmakeList.txt) and replace '%CMAKE_PATH% ../ -A x64'
 rem with '%CMAKE_PATH% ../ -A Win32'."
 %CMAKE_PATH% ../ -A x64
 %CMAKE_PATH% --build . --config Release
+
+rem 'After successful compilation "toolkit.py", "_toolkit.pyd", "epanet2.dll" will be created. You can start using the toolkit by importing the module "toolkit.py".
 
 cd ..
 pause


### PR DESCRIPTION
Added a `.bat` file to invoke compilation of the python wrapper for EPANET 2.2 from within a Windows based system. Small changes to the `CmakeList.txt` were made. 