### PR TITLE
applying swmm toolkit fix for compatibility with SWIG>=4.3

### DIFF
--- a/owa-epanet/wrapper/toolkit.i
+++ b/owa-epanet/wrapper/toolkit.i
@@ -24,6 +24,39 @@
 }
 
 /* TYPEMAP FOR IGNORING INT ERROR CODE RETURN VALUE */
+/*
+This is the same logic applied in swmm toolkit to handle a breaking change 
+introduced in the version 4.3 of SWIG. Credit: karosc
+
+See https://github.com/karosc/swmm-python/commit/1ef854ac469c1e2df29f9bb1ed718361df79cc95
+*/
+%header %{
+SWIGINTERN PyObject*
+Custom_SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
+    if (!result) {
+    result = obj;
+    } else if (result == Py_None) {
+    SWIG_Py_DECREF(result);
+    result = obj;
+    } else {
+    if (!PyList_Check(result)) {
+        PyObject *o2 = result;
+        result = PyList_New(1);
+        if (result) {
+        PyList_SET_ITEM(result, 0, o2);
+        } else {
+        SWIG_Py_DECREF(obj);
+        return o2;
+        }
+    }
+    PyList_Append(result,obj);
+    SWIG_Py_DECREF(obj);
+    }
+    return result;
+}
+#define SWIG_Python_AppendOutput Custom_SWIG_Python_AppendOutput
+%}
+
 %typemap(out) int {
     $result = Py_None;
     Py_INCREF($result);


### PR DESCRIPTION
This applies a modification to `owa-epanet/wrapper/toolkit.i` that resolves an issue that was introduced with SWIG 4.3. This is nearly identical to the fix that was applied to the SWMM toolkit [here](https://github.com/karosc/swmm-python/commit/1ef854ac469c1e2df29f9bb1ed718361df79cc95). 

Without this change, swig-wrapped functions that "return None no longer implicitly return void" due to [these changes](https://github.com/swig/swig/commit/cd39cf132c96a0887be07c826b80804d7677a701). This seemingly causes functions to return a list with two elements, where the first element is None and the second element is (likely) the object intended to be returned by the function. In practice this results in `TypeErrors`, for example:

```
Traceback (most recent call last):
  File "/Users/adamerispaha/code/mws-test/tests/test_run.py", line 38, in test_run_small_inp_downloaded
    self.assertTrue(run_inp(os.path.join(MODELS_DIR, 'small.inp'), collection_interval=120*60))
  File "/Users/adamerispaha/code/mws-test/src/run.py", line 10, in run_inp
    with Network(file_path=file_path, collection_interval=collection_interval) as net:
  File "/Users/adamerispaha/code/mws-test/.venv/lib/python3.10/site-packages/epanetwrapper/network/network.py", line 76, in __enter__
    toolkit.open(self.project, self.inp_file, self.report_file, self.output_file)
  File "/Users/adamerispaha/code/mws-test/.venv/lib/python3.10/site-packages/epanet/toolkit.py", line 671, in open
    return _toolkit.open(ph, inpFile, rptFile, outFile)
TypeError: in method 'open', argument 1 of type 'EN_Project'
```

The changes to the `owa-epanet/wrapper/toolkit.i` fixes this behavior.
